### PR TITLE
Consistent page screenshots for pdf and bitmap.

### DIFF
--- a/src/compile/compile.js
+++ b/src/compile/compile.js
@@ -4,7 +4,7 @@ import { parseContext, outputOptions } from './config.js';
 import { parseMarkdown } from '../parse/parse-markdown.js';
 import { cache } from '../util/cache.js';
 
-import { citations, code, runtime } from '../plugins/index.js';
+import { citations, code, notes, runtime } from '../plugins/index.js';
 import knitr from '../plugins/knitr/index.js';
 import pyodide from '../plugins/pyodide/index.js';
 
@@ -38,6 +38,7 @@ export async function compile(inputFile, options = {}) {
     ...plugins(metadata.plugins),
     runtime,
     code,
+    notes,
     citations
   ]);
 

--- a/src/compile/output/html.js
+++ b/src/compile/output/html.js
@@ -1,11 +1,10 @@
 import outputHTML from '../../output/html/index.js';
-import { crossref, header, notes, section, sticky } from '../../plugins/index.js';
+import { crossref, header, section, sticky } from '../../plugins/index.js';
 import { transformAST } from '../transform-ast.js';
 
 export default async function(ast, context, options) {
   const astHTML = await transformAST(ast, context, [
     crossref(options.numbered),
-    notes,
     sticky,
     header,
     section

--- a/src/plugins/convert/browser.js
+++ b/src/plugins/convert/browser.js
@@ -6,7 +6,6 @@ export async function getBrowser() {
   const onClose = () => browser = null;
   return browser || (browser = await launchBrowser({
     headless: true,
-    // defaultViewport: { width: 1200, height: 900 }
     defaultViewport: { width: 800, height: 600 }
   }, onClose));
 }
@@ -17,42 +16,9 @@ async function launchBrowser(options, onClose) {
     page() {
       return impl.newPage();
     },
-    pdf(options) {
-      return pdf(impl, options);
-    },
     async close() {
       await onClose(impl);
       await impl.close();
     }
   };
-}
-
-async function pdf(impl, { baseURL, css, html, path }) {
-  const page = await impl.newPage();
-  await page.emulateMediaType('print');
-  await page.setContent(`
-    ${baseURL ? `<base href="${baseURL}" />` : ''}
-    ${css || ''}
-    <style>
-      body > div,
-      body > form {
-        display: inline-block;
-        margin: 0px !important;
-      }
-      @media print {
-        body { break-inside: avoid; margin: 0; padding: 0; }
-      }
-    </style>
-    ${html}`);
-
-  const element = await page.$('body > *');
-  const { width, height } = await element.boundingBox();
-
-  await page.pdf({
-    path,
-    pageRanges: '1',
-    width: `${Math.ceil(width)}px`,
-    height: `${Math.ceil(height)}px`
-  });
-  await page.close();
 }

--- a/src/plugins/convert/convert-image.js
+++ b/src/plugins/convert/convert-image.js
@@ -1,20 +1,18 @@
 import path from 'node:path';
 import { clearProperties, createComponentNode, setValueProperty } from '../../ast/index.js';
+import { screenshot } from './screenshot.js';
 
 const ALLOWED_FORMATS = ['pdf', 'png', 'jpg'];
 const getAstId = handle => handle.evaluate(el => el.dataset.astId);
 
 export async function convertImage(handle, node, options) {
   const {
-    baseURL,
-    browser,
     convertDir,
-    css,
-    extract = el => el.innerHTML,
     format = 'pdf',
     inline = true,
     outputDir,
-    outputFilePrefix = 'lpub-convert-'
+    outputFilePrefix = 'lpub-convert-',
+    page
   } = options;
 
   if (!ALLOWED_FORMATS.includes(format)) {
@@ -26,16 +24,7 @@ export async function convertImage(handle, node, options) {
   const outputPath = path.join(outputDir, outputFile);
 
   // generate and store snapshot image
-  if (format === 'pdf') {
-    await browser.pdf({
-      baseURL,
-      css,
-      html: await handle.evaluate(extract),
-      path: outputPath
-    });
-  } else {
-    await handle.screenshot({ path: outputPath });
-  }
+  await screenshot(handle, { format, page, path: outputPath });
 
   // rewrite AST node
   const img = createComponentNode('image');

--- a/src/plugins/convert/index.js
+++ b/src/plugins/convert/index.js
@@ -67,10 +67,8 @@ export default function({
 
     const get = id => page.$(`[${AST_ID_KEY}="${id}"]`);
     const convertOptions = {
-      baseURL,
-      browser,
       convertDir,
-      css: await extractStyles(page),
+      page,
       format,
       outputDir: path.join(outputDir, convertDir)
     };
@@ -161,11 +159,4 @@ function isSVGImageNode(node) {
     return src.endsWith('.svg') || src.startsWith('data:image/svg+xml;');
   }
   return false;
-}
-
-async function extractStyles(page) {
-  return (await page.$$eval(
-    'head style, head link[rel="stylesheet"]',
-    elements => elements.map(el => el.outerHTML)
-  )).join('\n');
 }

--- a/src/plugins/convert/screenshot.js
+++ b/src/plugins/convert/screenshot.js
@@ -1,0 +1,74 @@
+/**
+ * Take a screenshot of a page element.
+ * Modifies element classes and styles to isolate selected content,
+ * hide other content, and screenshots the target element.
+ * @param {ElementHandle} handle The target element to screenshot
+ * @param {object} options Screenshot options
+ * @param {string} options.format The image format. One of pdf, png, or jpg.
+ * @param {Page} options.page The active page containing the target element
+ * @param {string} options.path The file path for the output PDF
+ */
+export async function screenshot(handle, { format, page, path }) {
+  // annotate target element and parents
+  await handle.evaluate(el => {
+    el.classList.add('lpub-screenshot-target');
+    let ancestor = el.parentElement;
+    while (ancestor) {
+      ancestor.classList.add('lpub-screenshot-parent');
+      ancestor = ancestor.parentElement;
+    }
+  });
+
+  // inject overriding styles
+  const styleHandle = await page.addStyleTag({
+    content: `
+      :not(.lpub-screenshot-parent, .lpub-screenshot-target, .lpub-screenshot-target *) {
+        display: none;
+      }
+
+      .lpub-screenshot-parent {
+        margin: 0 !important;
+        padding: 0 !important;
+      }
+
+      .lpub-screenshot-target {
+        display: inline-block;
+        margin: 0 !important;
+      }
+
+      .lpub-screenshot-target > * {
+        margin: 0 !important;
+      }
+
+      @media print {
+        body { break-inside: avoid; margin: 0; padding: 0; }
+      }
+    `
+  });
+
+  // take screenshot
+  if (format === 'pdf') {
+    const { width, height } = await handle.boundingBox();
+    await page.pdf({
+      path,
+      pageRanges: '1',
+      width: `${Math.ceil(width)}px`,
+      height: `${Math.ceil(height)}px`
+    });
+  } else {
+    await handle.screenshot({ path });
+  }
+
+  // remove style tag
+  await styleHandle.evaluate(el => el.remove());
+
+  // remove class annotations
+  await handle.evaluate(el => {
+    el.classList.remove('lpub-screenshot-target');
+    let ancestor = el.parentElement;
+    while (ancestor) {
+      ancestor.classList.remove('lpub-screenshot-parent');
+      ancestor = ancestor.parentElement;
+    }
+  });
+}


### PR DESCRIPTION
- Move screenshot logic to a single helper method, consolidated across formats.
- Apply the same page transformations and setup regardless of output format.
- Take screenshot from the original, live page with extraneous content hidden.

Close #14.