### PR TITLE
Support URI-encoded citation keys

### DIFF
--- a/src/parse/parse-pandoc-ast.js
+++ b/src/parse/parse-pandoc-ast.js
@@ -630,7 +630,10 @@ export class PandocASTParser {
 
       return createComponentNode(
         'citeref',
-        createProperties({ key, mode: getCiteMode(mode) }),
+        createProperties({
+          key: decodeURIComponent(key), // support URI-encoded DOIs
+          mode: getCiteMode(mode)
+        }),
         children
       );
     });


### PR DESCRIPTION
Perform URI decoding of parsed citation keys. This should allow parser-incompatible keys to be used (e.g., arbitrary DOI strings) without impacting standard keys (which should avoid the `%` character anyway).

Close #23.