### PR TITLE
fix: Show footnotes on small screens

### DIFF
--- a/packages/compiler/style/layout.css
+++ b/packages/compiler/style/layout.css
@@ -95,6 +95,7 @@ aside > :last-child {
 
 .inlinenote-number {
 	line-height: 1;
+	padding: 1px;
 }
 
 .float-left {
@@ -198,6 +199,7 @@ footer {
 
 	.inline-note-number {
 		cursor: pointer;
+		padding: 1px 4px;
 	}
 
 	.inline-note:not(.open) .note,

--- a/packages/compiler/style/themes/default/styles.css
+++ b/packages/compiler/style/themes/default/styles.css
@@ -79,10 +79,6 @@ aside,
 	background: var(--ref-color-light);
 }
 
-.inline-note-number {
-	padding: 1px;
-}
-
 .inline-note .note::before {
 	font-size: var(--smaller-size);
 }

--- a/packages/components/src/inline-note.js
+++ b/packages/components/src/inline-note.js
@@ -11,6 +11,9 @@ export class InlineNote extends ArticleElement {
 
   render() {
     const num = this.number;
-    return html`<span class="inline-note"><sup class="inline-note-number">${num}</sup><span class="note margin" data-number="${num}">${this.__children}</span></span>`;
+    return html`<span class="inline-note" @click=${(evt) => evt.target.parentElement.classList.toggle('open')}>
+      <sup class="inline-note-number">${num}</sup>
+      <span class="note margin" data-number="${num}">${this.__children}</span>
+    </span>`;
   }
 }


### PR DESCRIPTION
Fixes #24 

The CSS changes are to make the footnote number a teensy bit bigger on smaller screens.