### PR TITLE
fix: Compile correctly on Windows

### DIFF
--- a/packages/compiler/src/output/html/index.js
+++ b/packages/compiler/src/output/html/index.js
@@ -156,7 +156,8 @@ function entryScript({ root, bind, context, components, runtime }) {
 
   components.forEach(entry => {
     const spec = entry.default ? entry.import : `{ ${entry.import} }`;
-    script.push(`import ${spec} from '${entry.file}';`);
+    const filePath = entry.file.replaceAll('\\', '/'); // escape Windows paths
+    script.push(`import ${spec} from '${filePath}';`);
   });
 
   const imports = [

--- a/packages/compiler/src/resolve/node-resolver.js
+++ b/packages/compiler/src/resolve/node-resolver.js
@@ -4,7 +4,7 @@ export function nodeResolver(
   baseURL = new URL('../..', import.meta.url)
 ) {
   const { resolve } = createRequire(baseURL);
-  const localPattern = /^(?:\.\/|\.\.\/|\/)/;
+  const localPattern = /^(?:\.\/|\.\.\/|\/|[A-Za-z]:)/;
 
   return (id, prefix = '') => {
     const pkg = `${id}/package.json`;


### PR DESCRIPTION
Fixes compilation errors on Windows because Windows file paths are different from UNIX paths:

* Windows absolute paths start with a letter like `C:` instead of `/`
* Windows paths use `\` instead of `/`, so they have to be escaped or converted to the UNIX form when creating `entry.js`