### PR TITLE
Add appendix section support.

### DIFF
--- a/packages/compiler/src/output/html/index.js
+++ b/packages/compiler/src/output/html/index.js
@@ -18,10 +18,10 @@ export default async function(ast, context, options) {
     context,
     [
       htmlCode,
+      section,
       crossref(context.numbered),
       sticky,
-      header,
-      section
+      header
     ]
   );
   return outputHTML(ast, context, options);

--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -192,13 +192,18 @@ function extractNode(node, tex) {
   switch (name) {
     case 'abstract':
     case 'acknowledgments':
+    case 'appendix':
+      // extract as-is below
       break;
     case 'latex:preamble':
+      // extract as new preamble node
       return { name: 'preamble', content: node.children[0].value };
     case 'figure':
+      // extract if the figure is a teaser
       name = hasClass(node, 'teaser') ? 'teaser' : null;
       break;
     default:
+      // do not extract
       name = null;
   }
   if (name) {

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -153,12 +153,13 @@ export class TexFormat {
         return this.vspace(ast) + this.command(ast, 'caption');
       case 'raw':
         return this.raw(ast);
-      case 'bibliography':
       case 'abstract':
-      case 'teaser':
-      case 'references':
       case 'acknowledgments':
+      case 'appendix':
+      case 'bibliography':
       case 'latex:preamble':
+      case 'references':
+      case 'teaser':
         return '';
       default:
         return `\\textbf{${ast.name}?}\n\n`;
@@ -178,8 +179,8 @@ export class TexFormat {
   }
 
   header(ast, level) {
-    // TODO: nonumber?
-    return `\\${repeat('sub', level)}section{${this.fragment(ast)}}`
+    const nonum = bool(getPropertyValue(ast, 'nonumber')) ? '*' : '';
+    return `\\${repeat('sub', level)}section${nonum}{${this.fragment(ast)}}`
       + this.label(ast, 'sec')
       + '\n\n';
   }

--- a/packages/compiler/src/parse/markdown/index.js
+++ b/packages/compiler/src/parse/markdown/index.js
@@ -9,6 +9,7 @@ function defaultParseContext() {
     fence: [
       'abstract',
       'acknowledgments',
+      'appendix',
       'aside',
       'figure',
       'table',

--- a/packages/compiler/src/plugins/section/index.js
+++ b/packages/compiler/src/plugins/section/index.js
@@ -1,27 +1,42 @@
 import {
-  createComponentNode, createProperties, createTextNode, replaceChild, visitNodes
+  createComponentNode, createProperties, createTextNode, replaceChild,
+  setValueProperty, visitNodes
 } from '@living-papers/ast';
 
 // TODO pass in from context?
 const aliases = new Map([
   ['abstract', 'Abstract'],
   ['acknowledgments', 'Acknowledgments'],
+  ['appendix', null],
   ['references', 'References']
 ]);
+
+function isHeader(node) {
+  return node.name && /h\d/.test(node.name);
+}
 
 // TODO maintain one-to-one top-level AST mapping (div.name)?
 export default function(ast) {
   visitNodes(ast.article, (node, parent) => {
     if (aliases.has(node.name)) {
+      // special sections should not contain numbered sections
+      visitNodes(node, child => {
+        if (isHeader(child)) {
+          setValueProperty(child, 'nonumber', true);
+        }
+      });
+
+      // extract section content
+      // add a header if alias is defined
       const alias = aliases.get(node.name);
-      replaceChild(parent, node, [
+      const header = alias ? [
         createComponentNode(
           'h1',
           createProperties({ nonumber: true }),
           [ createTextNode(alias) ]
-        ),
-        ...node.children
-      ]);
+        )
+      ] : [];
+      replaceChild(parent, node, [...header, ...node.children]);
     }
   });
   return ast;

--- a/templates/latex/acm-article/template.tex
+++ b/templates/latex/acm-article/template.tex
@@ -213,6 +213,11 @@
 \bibliography{<<.>>}
 <</bibtex>>
 
+<<#appendix>>
+\appendix
+<<.>>
+<</appendix>>
+
 \end{document}
 \endinput
 

--- a/templates/latex/article/template.tex
+++ b/templates/latex/article/template.tex
@@ -94,4 +94,9 @@
 \bibliography{<<.>>}
 <</bibtex>>
 
+<<#appendix>>
+\appendix
+<<.>>
+<</appendix>>
+
 \end{document}

--- a/templates/latex/ieee-tvcg-journal/template.tex
+++ b/templates/latex/ieee-tvcg-journal/template.tex
@@ -177,5 +177,10 @@
 \bibliography{<<.>>}
 <</bibtex>>
 
+<<#appendix>>
+\appendix
+<<.>>
+<</appendix>>
+
 \end{document}
 

--- a/templates/latex/ieee-vgtc-conference/template.tex
+++ b/templates/latex/ieee-vgtc-conference/template.tex
@@ -158,4 +158,9 @@
 \bibliography{<<.>>}
 <</bibtex>>
 
+<<#appendix>>
+\appendix
+<<.>>
+<</appendix>>
+
 \end{document}


### PR DESCRIPTION
A fenced appendix block will now generate appendix sections. Headers within the appendix are not numbered.

- All LaTeX templates have been updated to support appendices, placed after the references.
- HTML output will place the appendix sections where they appear within the source document order. We can consider changing this (placing appendices after references) or add configuration options in the future.

Example:
```
::: appendix
# Appendix A: Some Stuff

Text.

# Appendix B: More Stuff

More text.
:::
```

Close #42.