### PR TITLE
Improve image generation and sizing control.

### DIFF
--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -21,6 +21,7 @@ export {
   setProperty,
   setValueProperty,
   removeProperty,
+  extractProperties,
   hasClass,
   getClasses,
   removeClass,

--- a/packages/ast/src/util.js
+++ b/packages/ast/src/util.js
@@ -123,6 +123,22 @@ export function clearProperties(node) {
 }
 
 /**
+ * Extract properties from an AST node.
+ * @param {object} node The AST node.
+ * @param {(k: string) => boolean} test A predicate function to test is a key should be extracted.
+ * @returns {object} A new properties object with extracted properties.
+ */
+ export function extractProperties(node, test) {
+  const props = {};
+  for (const key of getPropertyKeys(node)) {
+    if (test(key)) {
+      props[key] = getProperty(node, key);
+    }
+  }
+  return props;
+}
+
+/**
  * Retrieves an array of property keys for a node.
  * @param {object} node The AST node.
  * @return {string[]} The property keys, or an empty array if none.

--- a/packages/compiler/src/output/html/alias.js
+++ b/packages/compiler/src/output/html/alias.js
@@ -24,6 +24,10 @@ export function aliasComponent(name) {
 }
 
 export function aliasProperty(name) {
+  // drop properties that target other output formats
+  if (name.includes(':')) return null;
+
+  // map non-standard properties to the "data-" namespace
   switch (name) {
     case 'bind': return 'data-bind';
     case 'bind-set': return 'data-bind-set';

--- a/packages/compiler/src/output/html/ast-to-html.js
+++ b/packages/compiler/src/output/html/ast-to-html.js
@@ -50,6 +50,7 @@ function renderProps(props, ctx) {
   for (const propKey in props) {
     const { type, value } = props[propKey];
     const key = aliasProperty(propKey);
+    if (!key) continue;
 
     if (type === 'variable' || type === 'expression') {
       ctx.attrs.push([_id(), key, value]);

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -248,7 +248,7 @@ export class TexFormat {
   image(ast) {
     const src = sanitizeFile(getPropertyValue(ast, 'src'));
     const alt = getPropertyValue(ast, 'alt');
-    const arg = 'width=\\linewidth';
+    const arg = getImageParams(ast);
     if (alt) {
       return `\\begin{figure}[h]
   \\centering
@@ -400,6 +400,22 @@ export class TexFormat {
     const vsp = this.options.vspace.get(ast.name);
     return vsp ? `\\vspace{${vsp}}\n` : '';
   }
+}
+
+function getImageParams(ast) {
+  const w = getPropertyValue(ast, 'latex:width') ?? getPropertyValue(ast, 'width');
+  if (typeof w === 'string') {
+    if (w.endsWith('%')) {
+      // scale width by given percentage (if under 100%)
+      const v = +w.slice(0, -1);
+      if (v < 100) return `width=0.${v}\\linewidth`;
+    } else {
+      // pass custom width setting through as-is
+      return `width=${w}`;
+    }
+  }
+  // default image size to current line width
+  return 'width=\\linewidth';
 }
 
 function tableAlignment(ast) {

--- a/packages/compiler/src/plugins/convert/index.js
+++ b/packages/compiler/src/plugins/convert/index.js
@@ -90,6 +90,7 @@ export default function({
     // convert svg images
     const imageOptions = {
       ...convertOptions,
+      resize: true,
       extract: el => el.outerHTML
     };
     for (const id of svg) {

--- a/packages/compiler/src/plugins/convert/screenshot.js
+++ b/packages/compiler/src/plugins/convert/screenshot.js
@@ -42,12 +42,16 @@ export async function screenshot(handle, { format, page, path }) {
       }
 
       .lpub-screenshot-parent {
+        position: static;
         margin: 0 !important;
         padding: 0 !important;
       }
 
       .lpub-screenshot-target {
         display: inline-block;
+        position: absolute;
+        left: 0;
+        top: 0;
         margin: 0 !important;
       }
 


### PR DESCRIPTION
- Improve sizing and cropping of PDF screenshot capture.
- Add latex output image width control: use `latex:width` (if defined) or `width` (otherwise).
  - Percentage values (e.g, `80%`) will proportionally scale images.
  - Other width values will be written to latex output unedited.
- Suppress non-HTML attributes from propagating to HTML output.
- Add `extractProperties` AST utility.