### PR TITLE
Add figure images to esm output, refactor convert transforms.

### DIFF
--- a/packages/compiler/src/output/esm/index.js
+++ b/packages/compiler/src/output/esm/index.js
@@ -1,9 +1,23 @@
 import path from 'node:path';
+import { cloneAST, transformAST } from '@living-papers/ast';
+import { convertFigures } from '../../plugins/index.js';
 import { copy, mkdirp, writeFile } from '../../util/fs.js';
 import { bundleJS } from '../bundler.js';
 
-// TODO: include images of figures, tables, equations?
 export default async function(ast, context, options) {
+  const { output } = context;
+  const { figures = true, ...esmOptions } = options;
+  ast = await transformAST(
+    cloneAST(ast),
+    context,
+    figures ? [
+      convertFigures({...(options.convert || {}), html: output.html})
+    ] : []
+  );
+  return outputESM(ast, context, esmOptions);
+}
+
+export async function outputESM(ast, context, options) {
   const { inputFile, outputDir, tempDir } = context;
   const {
     jsFile = `${path.parse(inputFile).name}.mjs`,

--- a/packages/compiler/src/plugins/convert/browser.js
+++ b/packages/compiler/src/plugins/convert/browser.js
@@ -2,11 +2,14 @@ import puppeteer from 'puppeteer';
 
 let browser;
 
-export async function getBrowser() {
+export async function getBrowser({
+  headless = true,
+  viewport = { width: 800, height: 600 }
+} = {}) {
   const onClose = () => browser = null;
   return browser || (browser = await launchBrowser({
-    headless: true,
-    defaultViewport: { width: 800, height: 600 }
+    headless,
+    defaultViewport: viewport
   }, onClose));
 }
 

--- a/packages/compiler/src/plugins/convert/convert-figures.js
+++ b/packages/compiler/src/plugins/convert/convert-figures.js
@@ -1,0 +1,64 @@
+import { getPropertyValue, setValueProperty, visitNodes } from '@living-papers/ast';
+import { renderPage } from './render-page.js';
+import { screenshot } from './screenshot.js';
+
+const AST_ID_KEY = 'data-ast-id';
+
+export default function({
+  html = {},
+  delay = 0,
+  format = 'png',
+  names = ['figure', 'teaser', 'equation', 'table']
+} = {}) {
+  return async (ast, context) => {
+    const { logger } = context;
+    const nameSet = new Set(names);
+    const nodes = collectNodes(ast.article, node => nameSet.has(node.name));
+    const get = id => page.$(`[${AST_ID_KEY}="${id}"]`);
+
+    // exit early if no conversion is needed
+    if (nodes.size === 0) return ast;
+
+    logger.debug('Convert: generate figure environment images');
+
+    // render article page in puppeteer
+    const opts = { html, delay, viewport: { deviceScaleFactor: 2, width: 1200, height: 900 } };
+    const { page, close } = await renderPage(ast, context, opts);
+
+    // hide captions and equation tags
+    const css = `figcaption, .katex .tag { display: none; }`;
+    const options = { page, format, css, encoding: 'base64' };
+
+    // annotate nodes with image data urls
+    for (const [id, node] of nodes) {
+      const data = await screenshot(await get(id), options); // generate image
+      const url = `data:image/png;base64,${data}`; // create data url
+      setValueProperty(node, 'data-url', url); // update AST node
+    }
+
+    // shutdown puppeteer and proxy server
+    await close();
+
+    return ast;
+  }
+}
+
+function collectNodes(article, test) {
+  const nodes = new Map;
+  let _id = 0;
+
+  function add(node) {
+    let id = getPropertyValue(node, AST_ID_KEY);
+    if (id == null) {
+      id = String(++_id);
+      setValueProperty(node, AST_ID_KEY, id);
+      nodes.set(id, node);
+    }
+  }
+
+  visitNodes(article, node => {
+    if (test(node)) add(node);
+  });
+
+  return nodes;
+}

--- a/packages/compiler/src/plugins/convert/render-page.js
+++ b/packages/compiler/src/plugins/convert/render-page.js
@@ -1,0 +1,55 @@
+import { outputHTML } from '../../output/html/index.js';
+import { getBrowser } from './browser.js';
+import { startServer, stopServer } from './file-proxy-server.js';
+
+export async function renderPage(ast, context, {
+  html = {},
+  delay = 0,
+  ...browserOptions
+} = {}) {
+  const { inputDir, logger } = context;
+
+  // launch puppeteer and proxy server
+  const [browser, port] = await Promise.all([
+    getBrowser(browserOptions),
+    startServer(inputDir)
+  ]);
+
+  // prepare html options
+  const baseURL = `http://localhost:${port}/`;
+  const htmlOptions = {
+    ...html,
+    baseURL,
+    selfContained: true,
+    htmlFile: null
+  };
+
+  // load self-contained HTML
+  const page = await browser.page();
+  await page.emulateMediaType('print');
+  await page.setContent(await outputHTML(ast, context, htmlOptions));
+  if (+delay) {
+    logger.debug(`Convert: waiting ${+delay} ms for article load`);
+    await page.waitForTimeout(+delay);
+  }
+
+  // enable debugging from the browser in the node console
+  page.on('console', async (msg) => {
+    const msgArgs = msg.args();
+    for (let i = 0; i < msgArgs.length; ++i) {
+      logger.debug(await msgArgs[i].jsonValue());
+    }
+  });
+
+  return {
+    page,
+    close: async () => {
+      // shutdown proxy server and puppeteer
+      await page.close();
+      await Promise.all([
+        stopServer(),
+        browser.close()
+      ]);
+    }
+  }
+}

--- a/packages/compiler/src/plugins/convert/screenshot.js
+++ b/packages/compiler/src/plugins/convert/screenshot.js
@@ -8,7 +8,7 @@
  * @param {Page} options.page The active page containing the target element
  * @param {string} options.path The file path for the output PDF
  */
-export async function screenshot(handle, { format, page, path }) {
+export async function screenshot(handle, { format, page, path, encoding, css = '' }) {
   // handle inline content by injecting spans to ensure CSS is applied
   // TODO: find a better solution to this issue?
   await handle.evaluate(el => {
@@ -40,13 +40,11 @@ export async function screenshot(handle, { format, page, path }) {
       :not(.lpub-screenshot-parent, .lpub-screenshot-target, .lpub-screenshot-target *) {
         display: none;
       }
-
       .lpub-screenshot-parent {
         position: static;
         margin: 0 !important;
         padding: 0 !important;
       }
-
       .lpub-screenshot-target {
         display: inline-block;
         position: absolute;
@@ -54,18 +52,18 @@ export async function screenshot(handle, { format, page, path }) {
         top: 0;
         margin: 0 !important;
       }
-
       .lpub-screenshot-target > * {
         margin: 0 !important;
       }
-
       @media print {
         body { break-inside: avoid; margin: 0; padding: 0; }
       }
+      ${css}
     `
   });
 
   // take screenshot
+  let shot;
   if (format === 'pdf') {
     const { width, height } = await handle.boundingBox();
     await page.pdf({
@@ -75,7 +73,7 @@ export async function screenshot(handle, { format, page, path }) {
       height: `${Math.ceil(height)}px`
     });
   } else {
-    await handle.screenshot({ path });
+    shot = await handle.screenshot({ type: format, path, encoding });
   }
 
   // remove style tag
@@ -90,4 +88,6 @@ export async function screenshot(handle, { format, page, path }) {
       ancestor = ancestor.parentElement;
     }
   });
+
+  return shot;
 }

--- a/packages/compiler/src/plugins/index.js
+++ b/packages/compiler/src/plugins/index.js
@@ -2,6 +2,7 @@ export { default as citations } from './citations/index.js';
 export { default as htmlCode } from './code/html-code.js';
 export { default as code } from './code/index.js';
 export { default as convert } from './convert/index.js';
+export { default as convertFigures } from './convert/convert-figures.js';
 export { default as crossref } from './crossref/index.js';
 export { default as header } from './header/index.js';
 export { default as notes } from './notes/index.js';

--- a/packages/paper-api/src/paper.js
+++ b/packages/paper-api/src/paper.js
@@ -1,5 +1,5 @@
 import {
-  extractText, queryNode, queryNodes, setParentNodes
+  extractText, getPropertyValue, queryNode, queryNodes, setParentNodes
 } from '@living-papers/ast';
 
 const ABSTRACT = 'abstract';
@@ -108,5 +108,20 @@ export class Paper {
 
   get equationText() {
     return this.equationNodes.map(node => extractText(node));
+  }
+
+  figureImage(index) {
+    const node = this.figureNodes[index];
+    return node && getPropertyValue(node, 'data-url');
+  }
+
+  tableImage(index) {
+    const node = this.tableNodes[index];
+    return node && getPropertyValue(node, 'data-url');
+  }
+
+  equationImage(index) {
+    const node = this.equationNodes[index];
+    return node && getPropertyValue(node, 'data-url');
   }
 }


### PR DESCRIPTION
- Add `convertFigures` transform to render figure images and annotate AST with data url image properties.
- Add methods to the paper API to programmatically access figure, table, and equation images.
- Refactor `convert` transform internals for greater modularity.