### PR TITLE
Add getPropertyBoolean AST util.

### DIFF
--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -29,6 +29,7 @@ export {
   getPropertyKeys,
   getPropertyType,
   getPropertyValue,
+  getPropertyBoolean,
   hasProperty,
   hasExpressionProperty,
   getProperty,

--- a/packages/ast/src/properties.js
+++ b/packages/ast/src/properties.js
@@ -129,6 +129,20 @@ export function getPropertyValue(node, key) {
 }
 
 /**
+ * Retrieves the value for a node property as a boolean. This method interprets
+ * string values: if a property value is undefined, null, false, 0, an empty
+ * string, or the string 'false' (ignoring case), the return value is false.
+ * Otherwise, this method returns true.
+ * @param {object} node The AST node.
+ * @param {string} key The property key.
+ * @return {boolean} The property value as an interpreted boolean.
+ */
+export function getPropertyBoolean(node, key) {
+  const value = node?.properties?.[key]?.value;
+  return !!value && String(value).toLowerCase() !== 'false';
+}
+
+/**
  * Test if a property with the given key is defined on a node.
  * @param {object} node The AST node.
  * @param {string} key The property key.

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -1,5 +1,5 @@
 import {
-  getChildren, getClasses, getPropertyValue,
+  getChildren, getClasses, getPropertyValue, getPropertyBoolean,
   hasClass, hasProperty, isTextNode
 } from '@living-papers/ast';
 
@@ -8,10 +8,6 @@ function repeat(str, n) {
   let s = str;
   while (--n > 0) s += str;
   return s;
-}
-
-function bool(value) {
-  return String(value).toLowerCase() !== 'false';
 }
 
 export class TexFormat {
@@ -179,7 +175,7 @@ export class TexFormat {
   }
 
   header(ast, level) {
-    const nonum = bool(getPropertyValue(ast, 'nonumber')) ? '*' : '';
+    const nonum = getPropertyBoolean(ast, 'nonumber') ? '*' : '';
     return `\\${repeat('sub', level)}section${nonum}{${this.fragment(ast)}}`
       + this.label(ast, 'sec')
       + '\n\n';
@@ -314,7 +310,7 @@ export class TexFormat {
     // TODO throw error if interpolated?
     const code = getPropertyValue(ast, 'code') ?? ast.children[0].value;
     const env = getPropertyValue(ast, 'type') || 'align';
-    const nonum = bool(getPropertyValue(ast, 'nonumber'));
+    const nonum = getPropertyBoolean(ast, 'nonumber');
     return this.vspace(ast)
       + this.env(env + (nonum ? '*' : ''), code);
   }

--- a/packages/compiler/src/plugins/crossref/counter.js
+++ b/packages/compiler/src/plugins/crossref/counter.js
@@ -1,5 +1,5 @@
 import {
-  getChildren, getPropertyValue, setValueProperty, visitNodes
+  getChildren, getPropertyValue, getPropertyBoolean, setValueProperty, visitNodes
 } from '@living-papers/ast';
 
 const ID = 'id';
@@ -45,13 +45,7 @@ export default function(toKey, lookup) {
 }
 
 function hasNoNumber(node) {
-  return bool(getPropertyValue(node, NONUMBER));
-}
-
-function bool(value) {
-  return (typeof value === 'string')
-    ? value.toLowerCase() !== 'false'
-    : !!value;
+  return getPropertyBoolean(node, NONUMBER);
 }
 
 function isHeader(node) {

--- a/packages/compiler/src/plugins/knitr/codegen.js
+++ b/packages/compiler/src/plugins/knitr/codegen.js
@@ -1,5 +1,6 @@
 import {
-  createComponentNode, createProperties, getPropertyValue, hasProperty
+  createComponentNode, createProperties, getPropertyValue,
+  getPropertyBoolean, hasProperty
 } from '@living-papers/ast';
 
 const Bool = v => v && (v+'').toLowerCase() !== 'false' ? 'TRUE' : 'FALSE';
@@ -20,7 +21,7 @@ const OPTIONS = new Map([
 function getChunkOptions(node, applyDefaults = false) {
   const opt = [];
 
-  if (Bool(getPropertyValue(node, 'hide')) === 'TRUE') {
+  if (getPropertyBoolean(node, 'hide')) {
     opt.push(`include = FALSE`);
   }
 

--- a/packages/compiler/src/plugins/knitr/index.js
+++ b/packages/compiler/src/plugins/knitr/index.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import {
-  createProperties, hasProperty, getPropertyValue,
+  createProperties, hasProperty, getPropertyValue, getPropertyBoolean,
   removeProperty, setValueProperty, visitNodes
 } from '@living-papers/ast';
 import { pandoc } from '../../parse/markdown/pandoc.js';
@@ -66,10 +66,6 @@ function isRCode(node, lang) {
   return false;
 }
 
-function bool(v) {
-  return v && String(v).toLowerCase() !== 'false';
-}
-
 function updateAST(rnodes, output, lang, logger) {
   // log messages, return output blocks
   const blocks = output.filter(block => {
@@ -90,7 +86,7 @@ function updateAST(rnodes, output, lang, logger) {
 
   // remove hidden nodes
   const nodes = rnodes.filter(([node, parent]) => {
-    const hide = bool(getPropertyValue(node, 'hide'));
+    const hide = getPropertyBoolean(node, 'hide');
     if (hide) {
       parent.children = parent.children.filter(n => n !== node);
     }


### PR DESCRIPTION
- Add `getPropertyBoolean` AST utility to interpret boolean values (including for string-valued inputs).
- Use `getPropertyBoolean` in packages wherever AST boolean property checks are needed.