### PR TITLE
Add latex classOptions for document class.

### DIFF
--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -38,6 +38,7 @@ export async function outputLatex(ast, context, options) {
   const {
     template,
     tags = ['<<', '>>'],
+    classOptions,
     pdf = true,
     stdout = false,
     latexDir = path.join(pdf ? tempDir : outputDir, 'latex'),
@@ -89,6 +90,7 @@ export async function outputLatex(ast, context, options) {
   // Marshal template data
   const author = metadata.author || [{name: 'Unknown Author'}];
   const data = {
+    class_options: classOptions,
     date: tex.tex(metadata.date) || getDate(),
     title: tex.tex(metadata.title) || 'Untitled Article',
     author,

--- a/templates/latex/acm-article/template.tex
+++ b/templates/latex/acm-article/template.tex
@@ -35,7 +35,7 @@
 %%
 %%
 %% The first command in your LaTeX source must be the \documentclass command.
-\documentclass[manuscript,review]{acmart}
+\documentclass[<<class_options>><<^class_options>>manuscript<</class_options>>]{acmart}
 \RequirePackage{minted}
 
 %%

--- a/templates/latex/article/template.tex
+++ b/templates/latex/article/template.tex
@@ -2,8 +2,7 @@
 \PassOptionsToPackage{unicode}{hyperref}
 \PassOptionsToPackage{hyphens}{url}
 %
-\documentclass[
-]{article}
+\documentclass[<<class_options>>]{article}
 \usepackage{amsmath,amssymb}
 \usepackage{lmodern}
 \usepackage{iftex}

--- a/templates/latex/ieee-tvcg-journal/template.tex
+++ b/templates/latex/ieee-tvcg-journal/template.tex
@@ -1,7 +1,8 @@
-\documentclass[journal]{vgtc}                % final (journal style)
-%\documentclass[review,journal]{vgtc}         % review (journal style)
-%\documentclass[widereview]{vgtc}             % wide-spaced review
-%\documentclass[preprint,journal]{vgtc}       % preprint (journal style)
+\documentclass[<<class_options>><<^class_options>>journal<</class_options>>]{vgtc}
+%\documentclass[journal]{vgtc}           % final (journal style)
+%\documentclass[review,journal]{vgtc}    % review (journal style)
+%\documentclass[widereview]{vgtc}        % wide-spaced review
+%\documentclass[preprint,journal]{vgtc}  % preprint (journal style)
 
 %% Uncomment one of the lines above depending on where your paper is
 %% in the conference process. ``review'' and ``widereview'' are for review

--- a/templates/latex/ieee-vgtc-conference/template.tex
+++ b/templates/latex/ieee-vgtc-conference/template.tex
@@ -1,6 +1,6 @@
 % $Id: template.tex 11 2007-04-03 22:25:53Z jpeltier $
-
-\documentclass{vgtc}                          % final (conference style)
+\documentclass[<<class_options>>]{vgtc}
+%\documentclass{vgtc}                         % final (conference style)
 %\documentclass[review]{vgtc}                 % review
 %\documentclass[widereview]{vgtc}             % wide-spaced review
 %\documentclass[preprint]{vgtc}               % preprint


### PR DESCRIPTION
- Parameterize `latex` templates to set document class options, set by the `classOptions` property in `latex` document metadata.

Example:

```
---
latex:
  template: acm-article
  classOptions: sigconf,manuscript,review
---
```

cc: @joshuahhh 