### PR TITLE
Output namespaced components and properties.

### DIFF
--- a/packages/ast/src/classes.js
+++ b/packages/ast/src/classes.js
@@ -3,7 +3,7 @@ import {
 } from './properties.js';
 
 export function hasClass(node, className) {
-  return getClasses(node).indexOf(className) >= 0;
+  return getClasses(node).includes(className);
 }
 
 export function getClasses(node) {

--- a/packages/ast/src/index.js
+++ b/packages/ast/src/index.js
@@ -75,6 +75,11 @@ export {
 } from './set-parent-nodes.js';
 
 export {
+  namespace,
+  excludesNamespace
+} from './namespace.js';
+
+export {
   cloneAST
 } from './clone-ast.js';
 

--- a/packages/ast/src/namespace.js
+++ b/packages/ast/src/namespace.js
@@ -1,0 +1,18 @@
+import { getClasses } from './classes.js';
+
+export function namespace(name, defaultValue = null) {
+  const idx = name ? name.indexOf(':') : -1;
+  return idx < 0 ? defaultValue : name.slice(0, idx);
+}
+
+export function excludesNamespace(node, ns) {
+  if (namespace(node.name, ns) !== ns) {
+    return true;
+  }
+  for (const cls of getClasses(node)) {
+    if (cls.endsWith(':only')) {
+      return namespace(cls) !== ns;
+    }
+  }
+  return false;
+}

--- a/packages/compiler/src/output/html/alias.js
+++ b/packages/compiler/src/output/html/alias.js
@@ -1,3 +1,5 @@
+import { namespace } from '@living-papers/ast';
+
 const aliasMap = new Map([
   ['abstract', 'p'],
   ['acknowledgments', 'p'],
@@ -15,8 +17,7 @@ const aliasMap = new Map([
   ['quote', 'q'],
   ['sticky', 'div'],
   ['teaser', 'figure'],
-  ['latex:preamble', null], // TODO? filter all non-html prefixed elements
-  ['raw', null]
+  ['raw', null] // TODO pass through raw html?
 ]);
 
 export function aliasComponent(name) {
@@ -25,7 +26,7 @@ export function aliasComponent(name) {
 
 export function aliasProperty(name) {
   // drop properties that target other output formats
-  if (name.includes(':')) return null;
+  if (namespace(name, 'html') !== 'html') return null;
 
   // map non-standard properties to the "data-" namespace
   switch (name) {

--- a/packages/compiler/src/output/html/ast-to-html.js
+++ b/packages/compiler/src/output/html/ast-to-html.js
@@ -1,3 +1,4 @@
+import { excludesNamespace } from '@living-papers/ast';
 import { DATA_ATTR } from '@living-papers/runtime';
 import { aliasComponent, aliasProperty } from './alias.js';
 import { htmlEscape } from '../../util/html-escape.js';
@@ -27,7 +28,7 @@ function renderNode(node, ctx) {
   }
 
   const name = aliasComponent(node.name);
-  if (name == null) {
+  if (name == null || excludesNamespace(node, 'html')) {
     return '';
   } else if (name === 'br') {
     return '<br/>';

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -1,6 +1,6 @@
 import {
   getChildren, getClasses, getPropertyValue, getPropertyBoolean,
-  hasClass, hasProperty, isTextNode
+  hasClass, hasProperty, isTextNode, excludesNamespace
 } from '@living-papers/ast';
 
 function repeat(str, n) {
@@ -65,11 +65,13 @@ export class TexFormat {
 
   tex(ast) {
     if (ast == null) {
-      return undefined;
+      return;
     } else if (typeof ast === 'string') {
       return this.string(ast);
     } else if (ast.type === 'textnode') {
       return this.string(ast.value);
+    } else if (excludesNamespace(ast, 'latex')) {
+      return; // skip on non-latex output namespace
     }
 
     switch (ast.name) {


### PR DESCRIPTION
- Add support for output-specific components and properties. This provides support for content that targets a specific output type (`html` or `latex`). The `ast` and `esm` output types still include the full AST, inclusive of all output-specific blocks.

Examples:

```
::: latex:only
This content will be parsed as usual, but only included in latex output.
:::
```


```
::: { .latex:only }
Same as above. The `only` flag is just a class, so can be used in any fence or code block,
including as a class annotation for components such as `figure`, `equation`, etc.
:::
```


````
``` latex:only
Code block content passed to latex only.
```
````

```
![](img.png}{latex:width=80%}
Provides an image size property for `latex` but not `html` output.
```

cc: @joshuahhh 