### PR TITLE
Accept `latex` raw content in tex-format

### DIFF
--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -384,7 +384,7 @@ export class TexFormat {
 
   raw(ast) {
     const format = getPropertyValue(ast, 'format');
-    if (format !== 'tex') {
+    if (format !== 'tex' && format !== 'latex') {
       return '';
     } else if (hasProperty(ast, 'place')) {
       const node = this.options.places.get(getPropertyValue(ast, 'place'));

--- a/packages/compiler/src/plugins/include/index.js
+++ b/packages/compiler/src/plugins/include/index.js
@@ -47,13 +47,12 @@ export default async function(ast, context) {
 }
 
 async function getIncludedContent(node, context) {
-  const raw = getPropertyValue(node, 'raw');
+  const format = getPropertyValue(node, 'raw');
   const file = getPropertyValue(node, 'file');
   const inputFile = path.join(context.inputDir, file);
   try {
-    if (raw) {
+    if (format) {
       // include as raw format-specific content
-      const format = raw === 'latex' ? 'tex' : raw;
       return [
         createComponentNode(
           'raw',


### PR DESCRIPTION
- Update `tex-format` to accept raw text in both `tex` and `latex` format.
- Revert format mapping in `include` transform.

cc: @joshuahhh 

Close #72.