### PR TITLE
Implement Tooltip component

### DIFF
--- a/packages/components/css/cite.css
+++ b/packages/components/css/cite.css
@@ -1,3 +1,13 @@
+/*
+TODO: Move tooltip CSS to dedicated file
+ */
+.tooltip {
+  color: #3366CC;
+  font-weight: var(--ref-weight);
+  text-decoration: var(--ref-decoration);
+  cursor: pointer;
+}
+
 .cite-list::before {
   content: var(--cite-list-start);
 }

--- a/packages/components/src/cite-ref.js
+++ b/packages/components/src/cite-ref.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { ArticleElement } from './article-element.js';
+import { Tooltip } from './tooltip.js'
 
 export class CiteRef extends ArticleElement {
 
@@ -7,110 +8,76 @@ export class CiteRef extends ArticleElement {
     return {
       key: {type: String},
       mode: {type: String},
-      index: {type: Number}
+      index: {type: Number},
+      data: {type: Object}
     };
   }
 
   constructor() {
     super();
     this.mode = 'citation';
-    this.addEventListener('keydown', this.keyDown);
-    this.addEventListener('mousedown', this.openCitation);
-    this.addEventListener('focusout', this.focusOut);
   }
 
-  focusOut(event) {
-    if (!this.contains(event.relatedTarget)) {
-      this.closeCitation();
-    }
-  }
-
-  keyDown(event) {
-    if (event.key == 'Enter') {
-      this.openCitation();
-    } else if (event.key == 'Escape') {
-      this.closeCitation();
-    }
-  }
-
-  closeCitation() {
-    for (const child of this.querySelector('.cite-ref').children) {
-      child.style.display = 'none';
-    }
-  }
-
-  openCitation() {
-    for (const child of this.querySelector('.cite-ref').children) {
-      child.style.display = 'inline-block';
-    }
-  }
-
-  // Expand and collapse info content
   toggleContent(event) {
     if (!window.getSelection().toString()) {
       const summary = event.target.querySelector('summary');
       event.target.open
-        ? summary.textContent = summary.getAttribute('data-longtext')
+        ? summary.textContent = summary.getAttribute('data-longtext') 
         : summary.textContent = summary.getAttribute('data-shorttext');
       }
   }
 
-  initialChildNodes(nodes) {
-    this.__prefix = nodes[0];
-    this.__suffix = nodes[1];
-  }
-
-  citeData() {
-    return this.data || (
-      this.data = this.articleData()?.citations?.data[this.index - 1]
-    );
-  }
-
   render() {
-    const { key, index, mode, data = this.citeData() } = this;
+    const { key, data, index, mode} = this;
     const wrapper = html`<div class='cite-info-wrapper'></div>`;
 
     // Unresolved citation
     if (data == null) {
-      const ref = index ?? '??';
-      return html`<span class='cite-ref unresolved'>${ref}${wrapper}<div class='cite-info'>
+      return html`<span class='cite-ref unresolved'>??${wrapper}<div class='cite-info'>
         <b>Unresolved citation</b><br>"${key}"</div></span>`;
     }
 
     const { fullInfo, shortInfo } = infoBody(data);
     const desctext = descBody(data);
 
-    // Citation contents
+    // Conference/venue of the paper
     const subtitle = data.venue ? html`<div class='cite-head-subtitle'>${data.venue}</div>` : null;
-    const info = shortInfo
+
+    // Display authors
+    const info = shortInfo 
       ? html`<details class='cite-body-auth' @toggle=${this.toggleContent}>
               <summary data-shorttext=${shortInfo} data-longtext=${fullInfo}>${shortInfo}</summary>
             </details>`
       : html`<div class='cite-body-auth'>${fullInfo}</div>`;
-    const desc = data.abstract && data.abstract !== desctext
+
+
+    //Display description
+    const desc = data.abstract && data.abstract !== desctext 
       ? html`<details class='cite-body-desc' @toggle=${this.toggleContent}>
               <summary data-shorttext=${desctext} data-longtext=${data.abstract}>${desctext}</summary>
             </details>`
       : html`<div class='cite-body-desc'>${desctext}</div>`;
 
-    // Inline content
+    
     const body = mode === 'inline-author' ? inlineContent(data, index) : index;
 
-    return html`<span class='cite-ref' tabindex=0>${body}${wrapper}<div class='cite-info'>
+    // HTML to render in the tooltip
+    const renderHTML = html`${body}${wrapper}<div class='cite-info'>
       <a class='cite-head' href=${data.url} target="_blank" rel="noopener noreferrer" style="color: inherit;">
         <div class='cite-head-title'>${data.title}</div>${subtitle}
       </a>
       <div class='cite-body'>
         ${info}${desc}
       </div>
-    </div></span>`;
+    </div>`;
+
+    return html`${new Tooltip(renderHTML)}`;
   }
 }
 
 // Returns inline authors, or abbrev. if there are more than etal authors
-function inlineContent(data, index, etal = 2) {
-  const { author, title } = data;
-  if (!author || !author.length) return `${title} [${index}]`;
+function inlineContent(data, index, etal=2) {
+  const { author } = data;
 
   let authors = author[0].family;
   if (author.length === 2) {
@@ -118,32 +85,34 @@ function inlineContent(data, index, etal = 2) {
   } else if (author.length > etal) {
     authors += ' et al.';
   }
+
   return `${authors} [${index}]`;
 }
 
-function infoBody(data, maxAuthors = 2) {
-  const { author, year } = data;
-  const aMap = (author || []).map(({ given, family }) => {
-    return given
-      ? `${given.includes('.') ? given : given[0] + '.'} ${family}`
-      : family;
-  });
-  const fullInfo = `${year}` + (aMap.length ? ` \u2022 ${aMap.join(', ')}` : '');
-  const shortInfo = aMap.length > maxAuthors
-    ? `${year} \u2022 ${aMap.slice(0, maxAuthors).join(', ')} +${aMap.length - maxAuthors}`
+// Format of author and year
+function infoBody(data, maxAuthors=2) {
+  const { author, year } =  data;
+
+
+  const aMap = author.map(({ given, family }) => given 
+    ? `${given.includes('.') ? given : given[0] + '.'} ${family}` 
+    : family);
+  const fullInfo = `${year} \u2022 ${aMap.join(', ')}`;
+  const shortInfo = aMap.length > maxAuthors 
+    ? `${year} \u2022 ${aMap.slice(0, maxAuthors).join(', ')} +${aMap.length - maxAuthors}` 
     : null;
 
-  return { fullInfo, shortInfo };
+  return {fullInfo, shortInfo};
 }
 
-function descBody(
-  data,
-  charLimit = 300,
-  defaultDesc = 'No description is available for this article.'
-) {
+//Format of description
+function descBody(data, charLimit=300, defaultDesc='No description is available for this article.') {
   const { abstract, tldr } = data;
+
   const shortDesc = tldr || abstract || defaultDesc;
-  return shortDesc.length > charLimit
-    ? shortDesc.substring(0, shortDesc.substring(0, charLimit).lastIndexOf(' ')) + '... '
+  
+  // Limit description to 300 characters, adding '...' if character limit exceeds
+  return shortDesc.length > charLimit 
+    ? shortDesc.substring(0, shortDesc.substring(0, charLimit).lastIndexOf(' ')) + '... ' 
     : shortDesc;
 }

--- a/packages/components/src/tooltip.js
+++ b/packages/components/src/tooltip.js
@@ -1,0 +1,50 @@
+import { html } from 'lit';
+import { ArticleElement } from './article-element.js';
+
+
+export class Tooltip extends ArticleElement{
+
+    constructor(content) {
+      super();
+      this.content = content;
+      this.addEventListener('keydown', this.keyDown);
+      this.addEventListener('mousedown', this.show);
+      this.addEventListener('focusout', this.focusOut);
+  }
+
+  focusOut(event) {
+    if (!this.contains(event.relatedTarget)) {
+      this.hide();
+    }
+  }
+
+  //Pressing 'Enter' opens the tooltip and 'Escape' closes the tooltip
+  keyDown(event) {
+    if (event.key == 'Enter') {
+      this.show();
+    } else if (event.key == 'Escape') {
+      this.hide();
+    }
+  }
+
+  //Close/hide tooltip
+  hide() {
+    for (const child of this.querySelector('.tooltip').children) {
+      child.style.display = 'none';
+    }
+  }
+
+  //Open/show tooltip
+  show() {
+    for (const child of this.querySelector('.tooltip').children) {
+      child.style.display = 'inline-block';
+    }
+  }
+
+
+  render() {
+      return html`<span class='tooltip' tabindex=0>${this.content}</span>`;
+  }
+}
+
+customElements.define('my-tooltip', Tooltip)


### PR DESCRIPTION
Added a Tooltip component via `tooltip.js` that allows a more abstract and flexible implementation of tooltips. Other components can pass in the data and format they want to be displayed into the Tooltip and the Tooltip will handle the displaying, showing, and hiding of the tooltip on the page. 
Modified `cite-ref.js` to utilize this tooltip component for inline citations. 