### PR TITLE
add resizable, moveable figure tooltips to cross-ref

### DIFF
--- a/packages/components/css/cross-ref.css
+++ b/packages/components/css/cross-ref.css
@@ -29,3 +29,49 @@
 .cross-ref.eqn.full::before {
   content: var(--equation-prefix);
 }
+
+.fig-tooltip {
+  display: none;
+	background-color: white;
+	z-index: 1;
+	position: absolute;
+	filter: drop-shadow(3px 3px 3px rgba(0,0,0,0.2));
+	border: 1px solid #ccc;
+	cursor: auto;
+  min-width: 100px;
+  min-height: 100px;
+  width: 400px;
+  border-radius: 4px;
+  overflow: hidden;
+  resize: both;
+  transform: translate(-1.5em, 1.4em);
+}
+
+.fig-body {
+  padding: 0.5em;
+}
+
+.fig-controls a {
+  color: black;
+  padding: 0.15em;
+}
+
+.fig-controls a:hover {
+  background-color: #ddd;
+  cursor: pointer;
+}
+
+.fig-controls {
+  display: flex;
+  justify-content: right;
+  background-color: #eee;
+  border-bottom: 1px solid #ccc;
+}
+
+.fig-minimize::before {
+  content: '\2013';
+}
+
+.fig-close::before {
+  content: '\2716';
+}

--- a/packages/components/src/cross-ref.js
+++ b/packages/components/src/cross-ref.js
@@ -11,29 +11,83 @@ export class CrossRef extends ArticleElement {
     };
   }
 
-  goto(event) {
-    // prevent jump to referenced element
-    event.preventDefault();
+  constructor() {
+    super();
+    this.addEventListener('mousedown', this.show);
+  }
 
-    // add id to hash component of current URL
-    // do not change the page undo history
-    const id =`#${this.xref}`;
-    history.replaceState(null, null, id);
+  updated() {
+    this.dragElement(this.querySelector('.fig-controls'));
+  }
 
-    // smoothly scroll to referenced component
-    document.querySelector(id)
-      .scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  hide() {
+    this.querySelector('.fig-tooltip').style.display = 'none';
+  }
+
+  show() {
+    this.querySelector('.fig-tooltip').style.display = 'inline-block';
+  }
+
+  minimizeFigure() {
+    const tooltip = this.querySelector('.fig-tooltip');
+    tooltip.style.width = '400px';
+    tooltip.style.height = 'auto';
+  }
+
+  dragElement(el) {
+    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    const tooltip = this.querySelector('.fig-tooltip');
+    el.onmousedown = dragMouseDown;
+    
+    function dragMouseDown(e) {
+      e = e || window.event;
+      e.preventDefault();
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      document.onmouseup = () => {
+        document.onmouseup = null;
+        document.onmousemove = null;
+      };
+      document.onmousemove = elementDrag;
+    }
+  
+    const elementDrag = (e) => {
+      e = e || window.event;
+      e.preventDefault();
+      pos1 = pos3 - e.clientX;
+      pos2 = pos4 - e.clientY;
+      pos3 = e.clientX;
+      pos4 = e.clientY;
+      tooltip.style.top = (tooltip.offsetTop - pos2) + "px";
+      tooltip.style.left = (tooltip.offsetLeft - pos1) + "px";
+    }
   }
 
   render() {
-    // TODO? title tooltip
     const { type, xref, index, short } = this;
     const resolved = index != null;
+    const id = `#${xref}`;
     const cls = `cross-ref ${type}${!short ? ' full' : ''}`;
     if (resolved) {
-      return html`<a class=${cls} href="#${xref}" @click=${this.goto}>${index}</a>`;
+      return html`
+        <span class=${cls}>${index}</span>
+        <div class="fig-tooltip">
+            <div class="fig-controls">
+                    <a class="fig-minimize" @click=${this.minimizeFigure}></a>
+                    <a class="fig-close" @click=${this.hide}/></a>
+            </div>
+            ${renderFigureTooltipBody(id)}
+        </div>`;
     } else {
       return html`<a class="${cls} unresolved" title="Unresolved reference: ${xref}">?</a>`;
     }
   }
+}
+
+function renderFigureTooltipBody(id) {
+  const figCopy = document.querySelector(id).cloneNode({deep:true});
+  figCopy.className = 'figure';
+  figCopy.removeAttribute('id');
+  figCopy.querySelector('figcaption').removeAttribute('class');
+  return html`<div class="fig-body">${figCopy}</div>`;
 }


### PR DESCRIPTION
Demo: https://homes.cs.washington.edu/~tu21897/lpub/fast-kde/

- adds resizable, moveable figure tooltips to cross-ref
- still needs to be modified to use `tooltip.js` when `jh/tooltip` is finished

Default:
<img width="500" alt="Screenshot 2023-03-16 at 8 30 28 PM" src="https://user-images.githubusercontent.com/73036803/225806777-bfb84aba-ae86-4c98-a3f9-419cefc4c04c.png">

Resized:
<img width="500" alt="Screenshot 2023-03-16 at 8 30 41 PM" src="https://user-images.githubusercontent.com/73036803/225806804-d48b9a7a-1676-4025-bcf1-15ce81d32ee3.png">

Resized & Dragged:
<img width="500" alt="Screenshot 2023-03-16 at 8 31 56 PM" src="https://user-images.githubusercontent.com/73036803/225806812-b69f4e5d-1dc0-4150-9c2b-9484eca436e1.png">

