### PR TITLE
Add Observable module generation.

### DIFF
--- a/examples/reactive/import.md
+++ b/examples/reactive/import.md
@@ -1,0 +1,21 @@
+---
+title: Reactive Runtime Imports
+author:
+  - name: Living Papers Team
+    org: University of Washington
+output:
+  html: true
+---
+
+``` js
+viewof a = Inputs.range([0, 255], {step: 1, value: 200})
+```
+
+::: figure
+``` js
+import { plot } with { a } from './build/runtime.mjs'
+---
+plot
+```
+| A plot imported from another article runtime, with injected reactive variables!
+:::

--- a/examples/reactive/package.json
+++ b/examples/reactive/package.json
@@ -4,7 +4,7 @@
   "description": "Living Papers example article with reactive updates.",
   "repository": "uwdata/living-papers",
   "scripts": {
-    "build": "lpub -o build reactive.md"
+    "build": "lpub -o build reactive.md && lpub -o build/import import.md"
   },
   "devDependencies": {
     "@living-papers/cli": "*"

--- a/examples/reactive/reactive.md
+++ b/examples/reactive/reactive.md
@@ -6,6 +6,7 @@ author:
 output:
   html: true
   latex: true
+  runtime: true
 ---
 
 ``` js { hide=true }
@@ -20,7 +21,7 @@ viewof a = Inputs.range([0, 255], {step: 1, value: init})
 ``` js
 format = new Intl.NumberFormat().format
 ---
-Plot.plot({
+plot = Plot.plot({
   marginLeft: 50,
   y: { grid: true },
   marks: [
@@ -35,3 +36,6 @@ Plot.plot({
 :::
 
 The square of `js a` is `js format(a * a)`.
+
+Living Papers articles can import reactive runtime content from other articles.
+Here is [an article that reuses this article's plot](./import)!

--- a/packages/compiler/src/output/html/ast-to-script.js
+++ b/packages/compiler/src/output/html/ast-to-script.js
@@ -1,11 +1,17 @@
 import { setValueProperty } from '@living-papers/ast';
 import { CELL_VIEW, DATA_CELL } from '@living-papers/runtime';
-import { compile, generateModule, handler, splitCodeCells } from '@living-papers/runtime-compiler';
+import { compile, generateModule, generateObservableModule, handler, splitCodeCells } from '@living-papers/runtime-compiler';
 
 const isTrue = b => String(b).toLowerCase() === 'true';
 
 export function astToScript(ast) {
   return { ast, script: generateScript(gatherCode(ast)) };
+}
+
+export function astToModule(ast) {
+  const { cells } = gatherCode(ast);
+  const module = generateObservableModule(cells, compile);
+  return { ast, module };
 }
 
 function gatherCode(ast) {

--- a/packages/compiler/src/output/html/runtime.js
+++ b/packages/compiler/src/output/html/runtime.js
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import { mkdirp, writeFile } from '../../util/fs.js';
+import { astToModule } from './ast-to-script.js';
+
+export default async function(ast, context, options) {
+  const { outputDir } = context;
+  const {
+    jsFile = 'runtime.mjs',
+  } = options;
+
+  const { module } = astToModule(ast.article);
+
+  const outputPath = path.join(outputDir, jsFile);
+  await mkdirp(path.dirname(outputPath));
+  await writeFile(outputPath, module);
+  return outputPath;
+}

--- a/packages/compiler/src/output/index.js
+++ b/packages/compiler/src/output/index.js
@@ -1,5 +1,6 @@
 export { default as api } from './api/index.js';
 export { default as ast } from './ast/index.js';
 export { default as html } from './html/index.js';
+export { default as runtime } from './html/runtime.js';
 export { default as static } from './html/static.js';
 export { default as latex } from './latex/index.js';

--- a/packages/runtime-compiler/src/generate-module.js
+++ b/packages/runtime-compiler/src/generate-module.js
@@ -4,36 +4,22 @@ const _mutable = name => `mutable ${name}`;
 const _viewof = name => `viewof ${name}`;
 
 export function generateModule(exportName, codeCells, compile) {
-  let code = '';
-  let i = 0;
-  let v = 0;
+  if (!codeCells?.length) return '';
+  const { cells, defs } = processCells(codeCells, compile);
+  return generateImports(cells)
+    + `export function ${exportName}() {\n`
+    + generateCellFunctions(cells)
+    + `return [\n`
+    + defs.map(generateDefinition).join(',\n')
+    + '\n];\n}';
+}
 
-  if (!codeCells?.length) {
-    return '';
-  }
-
+export function processCells(codeCells, compile) {
   const cells = codeCells.map(compile);
 
-  // generate import statements
-  cells.forEach(cell => {
-    if (!cell.import) return;
-    code += `import define${++i} from "${_api(cell.body.source.value)}";\n`;
-  });
-  if (i > 0) code += '\n';
-
-  code += `export function ${exportName}() {\n`
-
-  // generate cell function definitions
-  cells.forEach(cell => {
-    if (cell.import) return;
-    const { fnargs, body, async, generator } = cell;
-    const fn = (async ? 'async ' : '') + 'function' + (generator ? '*' : '');
-    code += `${fn} _${++v}(${fnargs.join(',')}){${body}}\n\n`;
-  });
-
   // generate module definition
-  i = 0;
-  v = 0;
+  let i = 0;
+  let v = 0;
   const defs = [];
   cells.forEach((cell, idx) => {
     if (cell.import) {
@@ -67,14 +53,35 @@ export function generateModule(exportName, codeCells, compile) {
       }
     }
   });
-  code += `return [\n`
-    + defs.map(definition).join(',\n')
-    + '\n];\n}';
 
+  return { cells, defs };
+}
+
+// generate import statements
+function generateImports(cells) {
+  let code = '';
+  let i = 0;
+  cells.forEach(cell => {
+    if (!cell.import) return;
+    code += `import define${++i} from "${_api(cell.body.source.value)}";\n`;
+  });
+  return code + (code ? '\n' : '');
+}
+
+// generate cell function definitions
+function generateCellFunctions(cells) {
+  let code = '';
+  let v = 0;
+  cells.forEach(cell => {
+    if (cell.import) return;
+    const { fnargs, body, async, generator } = cell;
+    const fn = (async ? 'async ' : '') + 'function' + (generator ? '*' : '');
+    code += `${fn} _${++v}(${fnargs.join(',')}){${body}}\n\n`;
+  });
   return code;
 }
 
-function definition(v) {
+function generateDefinition(v) {
   let prop;
   if (v.defn) {
     const n = v.name ? `"${v.name}"` : 'null';
@@ -90,4 +97,38 @@ function definition(v) {
   }
   const cell = v.cell != null ? `, cell:${v.cell}` : '';
   return `  {${prop}${cell}}`;
+}
+
+export function generateObservableModule(codeCells, compile) {
+  if (!codeCells?.length) return '';
+  const { cells, defs } = processCells(codeCells, compile);
+
+  let code = '';
+  code += generateImports(cells);
+  code += generateCellFunctions(cells);
+  code += `export default function define(runtime, observer) {\n`;
+  code += ` const main = runtime.module();\n`;
+
+  let i = 0;
+  defs.forEach(def => {
+    if (def.module) {
+      code += ` const child${++i} = runtime.module(define${i});\n`
+    } else if (def.import) {
+      const args = [
+        JSON.stringify(def.import),
+        def.alias ? JSON.stringify(def.alias) : null,
+        `child${def.from}`
+      ].filter(x => x);
+      code += ` main.import(${args.join(', ')});\n`;
+    } else {
+      const { name, inputs, defn } = def;
+      const id = name ? JSON.stringify(name) : '';
+      const deps = inputs ? `[${inputs.map(i => JSON.stringify(i)).join(', ')}]` : '';
+      const args = [id, deps, defn].filter(x => x);
+      code += ` main.variable(observer(${id})).define(${args.join(', ')});\n`;
+    }
+  });
+  code += ` return main;\n}\n`;
+
+  return code;
 }

--- a/packages/runtime-compiler/src/index.js
+++ b/packages/runtime-compiler/src/index.js
@@ -1,3 +1,3 @@
 export { splitCodeCells, joinCodeCells } from './code-cells.js';
 export { compile, handler } from './compile.js';
-export { generateModule } from './generate-module.js';
+export { generateModule, generateObservableModule } from './generate-module.js';


### PR DESCRIPTION
- Add Observable-compatible `runtime` module generation.
- Refactor runtime compiler code.
- Update reactive example to test runtime imports from another article.