### PR TITLE
Support expression-valued image source.

### DIFF
--- a/packages/compiler/src/parse/markdown/parse-pandoc-ast.js
+++ b/packages/compiler/src/parse/markdown/parse-pandoc-ast.js
@@ -514,10 +514,11 @@ export class PandocASTParser {
   }
 
   parseImage(item) {
-    const [ attrs, alt, [src, title] ] = item;
+    const [ attrs, alt, [href, title] ] = item;
+    const src = href ? decodeURI(href) : undefined;
     const props = {
       alt: extractText(alt) || undefined,
-      src: src || undefined,
+      src,
       title: (title !== ':fig' && title) || undefined
     };
     return createComponentNode(

--- a/packages/compiler/test/data/article/observable.md
+++ b/packages/compiler/test/data/article/observable.md
@@ -33,6 +33,8 @@ $$x^2 = ${a*a}$$
 
 The square of `js a` is `js format(a * a)`.
 
+![IDL logo](`'http://idl.cs.washington.edu/static/images/logo/idl-logo.png'`)
+
 # Multi-Cell Code Blocks
 
 ``` js

--- a/packages/compiler/test/data/ast/observable.ast.json
+++ b/packages/compiler/test/data/ast/observable.ast.json
@@ -164,6 +164,26 @@
       },
       {
         "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "component",
+            "name": "image",
+            "properties": {
+              "alt": {
+                "type": "value",
+                "value": "IDL logo"
+              },
+              "src": {
+                "type": "expression",
+                "value": "'http://idl.cs.washington.edu/static/images/logo/idl-logo.png'"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "component",
         "name": "h1",
         "properties": {
           "id": {


### PR DESCRIPTION
- Update Markdown parser to properly parse backtick-quoted expressions, enabling reactive image source URL values.