### PR TITLE
Miscellaneous fixes

### DIFF
--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -237,17 +237,10 @@ export class TexFormat {
 
   image(ast) {
     const src = sanitizeFile(getPropertyValue(ast, 'src'));
-    const alt = getPropertyValue(ast, 'alt');
+    // TODO: find best way to incorporate alt text
+    // const alt = getPropertyValue(ast, 'alt');
     const arg = getImageParams(ast);
-    if (alt) {
-      return `\\begin{figure}[h]
-  \\centering
-  \\includegraphics[${arg}]{${src}}
-  \\caption{${alt}}
-  \\end{figure}\n`;
-    } else {
-      return `\\includegraphics[${arg}]{${src}}`;
-    }
+    return `\\includegraphics[${arg}]{${src}}`;
   }
 
   quoted(ast) {

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -21,9 +21,21 @@ export class TexFormat {
     let i = 0;
     let h = 0;
     for (; i < n; ++i) {
+      let j;
       let p;
+      let m = 0;
       const c = str[i];
       switch (c) {
+        case '-':
+          for (j = i + 1, p = '-'; j < n && str[j] === '-'; ++j, ++m) {
+            p += '\\/-';
+          }
+          if (j - i < 2) {
+            p = null;
+          }
+          break;
+        case '\'': p = '\\textquotesingle{}'; break;
+        case '`': p = '\\textasciigrave{}'; break;
         case '’': p = '\''; break;
         case '”': p = '\'\''; break;
         case '–': p = '--'; break;
@@ -52,6 +64,7 @@ export class TexFormat {
           b.push(str.slice(h, i));
         }
         b.push(p);
+        i += m;
         h = i + 1;
       }
     }

--- a/packages/compiler/test/parse/markdown-preprocess-test.js
+++ b/packages/compiler/test/parse/markdown-preprocess-test.js
@@ -97,6 +97,22 @@ describe('preprocess', () => {
     );
   });
 
+  it('does not modify fenced blocks within code blocks', () => {
+    test(
+      '```\n::: figure {#id}\n![](image.png)\n| Caption\n:::\n```',
+      '```\n::: figure {#id}\n![](image.png)\n| Caption\n:::\n```'
+    );
+    test(
+      '::: figure\n```\n::: figure {#id}\n![](image.png)\n| Caption\n:::\n```\n:::',
+      '::: {component=figure}\n```\n::: figure {#id}\n![](image.png)\n| Caption\n:::\n```\n:::'
+    );
+    test('```\n~~~ equation\n~~~\n```', '```\n~~~ equation\n~~~\n```');
+    test('````\n``` js\n```\n````', '````\n``` js\n```\n````');
+    test('~~~~\n``` js\n```\n~~~~', '~~~~\n``` js\n```\n~~~~');
+    test('````\n``` js\n```\n`````', '````\n``` js\n```\n`````');
+    test('~~~~\n``` js\n```\n~~~~~', '~~~~\n``` js\n```\n~~~~~');
+  });
+
   it('handles pipes', () => {
     test(':::\nfoo\n| bar', ':::\nfoo\n\n| bar');
     test(':::\nfoo\n| bar\n| baz', ':::\nfoo\n\n| bar\n| baz');


### PR DESCRIPTION
- Fix Markdown preprocessor to ignore content within code blocks.
- Fix latex output to properly handle dash sequences, single quotes, and backticks.
- Update latex output to not generate figure environment when alt text is present.
