### PR TITLE
Adjust tooltip layout and cross-ref tooltip width.

### DIFF
--- a/packages/components/css/cross-ref.css
+++ b/packages/components/css/cross-ref.css
@@ -35,7 +35,7 @@
 }
 
 .cross-ref-tooltip figure {
-  max-width: 400px;
+  width: 400px;
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
- Set cross-ref tooltip to a fixed width to avoid squeezes along page margins.
- Update tooltip layout calculations.