### PR TITLE
fix: Resolve transforms with Windows paths

### DIFF
--- a/packages/compiler/src/resolve/transforms.js
+++ b/packages/compiler/src/resolve/transforms.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
+import url from 'node:url';
 import { readFile } from '../util/fs.js';
-import url from 'url';
 
 export async function resolveTransforms(transforms, context) {
   const { inputDir, logger, resolve } = context;

--- a/packages/compiler/src/resolve/transforms.js
+++ b/packages/compiler/src/resolve/transforms.js
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { readFile } from '../util/fs.js';
+import url from 'url';
 
 export async function resolveTransforms(transforms, context) {
   const { inputDir, logger, resolve } = context;
@@ -47,8 +48,8 @@ export async function resolveTransforms(transforms, context) {
 }
 
 async function loadTransform(item, dir) {
-  const file = path.resolve(path.join(dir, item.file));
-  const module = await import(file);
+  const fileUrl = url.pathToFileURL(path.resolve(path.join(dir, item.file)));
+  const module = await import(fileUrl);
   // TODO support named imports as part of item?
   return module.default;
 }


### PR DESCRIPTION
Windows absolute file paths strike again :(

Before this PR, adding a transform in a project's `package.json` like this:

```json
"transforms": [
  {
    "name": "my-transform",
    "file": "src/my-transform.js"
  }
]
```
would cause this error (my drive is named `Q:`):
```
Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'q:'
```
because of https://github.com/nodejs/node/issues/31710.

This PR just uses the standard solution of `pathToFileURL` to load custom transforms correctly.