### PR TITLE
Properly format dynamic HTML attributes.

### DIFF
--- a/packages/compiler/test/compile/compile-test.js
+++ b/packages/compiler/test/compile/compile-test.js
@@ -52,6 +52,10 @@ describe('compile', () => {
     return compileTest('article/components.md');
   });
 
+  it('an article with dynamic properties', () => {
+    return compileTest('article/properties.md');
+  });
+
   it('an article with cross-references', () => {
     return compileTest('article/crossref.md', { warn: 3 });
   });

--- a/packages/compiler/test/data/article/properties.md
+++ b/packages/compiler/test/data/article/properties.md
@@ -1,0 +1,47 @@
+---
+title: Component Properties
+---
+
+~~~ js { hide=true }
+min = 1
+---
+max = 10
+---
+values = [1,2,5,10,100,1000]
+~~~
+
+# As Block Components {nonumber=true}
+
+Range (static):
+
+::: range-text {min=1 max=10 span=5}
+:::
+
+Range (dynamic):
+
+::: range-text {min=`min` max=`max` span=5}
+:::
+
+Option (static):
+
+::: option-text {options=[1,2,5,10,100,1000] span=5}
+:::
+
+Option (dynamic):
+
+::: option-text {options=`values` span=5}
+:::
+
+# As Inline Components {nonumber=true}
+
+Range (static):
+[:range-text:]{min=1 max=10 span=5}
+
+Range (dynamic):
+[:range-text:]{min=`min` max=`max` span=5}
+
+Option (static):
+[:option-text:]{options=[1,2,5,10,100,1000] span=5}
+
+Option (dynamic):
+[:option-text:]{options=`values` span=5}

--- a/packages/compiler/test/data/ast/properties.ast.json
+++ b/packages/compiler/test/data/ast/properties.ast.json
@@ -1,0 +1,279 @@
+{
+  "metadata": {
+    "title": "Component Properties"
+  },
+  "article": {
+    "type": "component",
+    "name": "article",
+    "children": [
+      {
+        "type": "component",
+        "name": "codeblock",
+        "properties": {
+          "language": {
+            "type": "value",
+            "value": "js"
+          },
+          "hide": {
+            "type": "value",
+            "value": "true"
+          }
+        },
+        "children": [
+          {
+            "type": "textnode",
+            "value": "min = 1\n---\nmax = 10\n---\nvalues = [1,2,5,10,100,1000]"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "h1",
+        "properties": {
+          "id": {
+            "type": "value",
+            "value": "as-block-components"
+          },
+          "nonumber": {
+            "type": "value",
+            "value": "true"
+          }
+        },
+        "children": [
+          {
+            "type": "textnode",
+            "value": "As Block Components"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Range (static):"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "range-text",
+        "properties": {
+          "min": {
+            "type": "value",
+            "value": "1"
+          },
+          "max": {
+            "type": "value",
+            "value": "10"
+          },
+          "span": {
+            "type": "value",
+            "value": "5"
+          }
+        }
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Range (dynamic):"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "range-text",
+        "properties": {
+          "min": {
+            "type": "expression",
+            "value": "min"
+          },
+          "max": {
+            "type": "expression",
+            "value": "max"
+          },
+          "span": {
+            "type": "value",
+            "value": "5"
+          }
+        }
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Option (static):"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "option-text",
+        "properties": {
+          "options": {
+            "type": "value",
+            "value": "[1,2,5,10,100,1000]"
+          },
+          "span": {
+            "type": "value",
+            "value": "5"
+          }
+        }
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Option (dynamic):"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "option-text",
+        "properties": {
+          "options": {
+            "type": "expression",
+            "value": "values"
+          },
+          "span": {
+            "type": "value",
+            "value": "5"
+          }
+        }
+      },
+      {
+        "type": "component",
+        "name": "h1",
+        "properties": {
+          "id": {
+            "type": "value",
+            "value": "as-inline-components"
+          },
+          "nonumber": {
+            "type": "value",
+            "value": "true"
+          }
+        },
+        "children": [
+          {
+            "type": "textnode",
+            "value": "As Inline Components"
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Range (static):\n"
+          },
+          {
+            "type": "component",
+            "name": "range-text",
+            "properties": {
+              "min": {
+                "type": "value",
+                "value": "1"
+              },
+              "max": {
+                "type": "value",
+                "value": "10"
+              },
+              "span": {
+                "type": "value",
+                "value": "5"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Range (dynamic):\n"
+          },
+          {
+            "type": "component",
+            "name": "range-text",
+            "properties": {
+              "min": {
+                "type": "expression",
+                "value": "min"
+              },
+              "max": {
+                "type": "expression",
+                "value": "max"
+              },
+              "span": {
+                "type": "value",
+                "value": "5"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Option (static):\n"
+          },
+          {
+            "type": "component",
+            "name": "option-text",
+            "properties": {
+              "options": {
+                "type": "value",
+                "value": "[1,2,5,10,100,1000]"
+              },
+              "span": {
+                "type": "value",
+                "value": "5"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "component",
+        "name": "p",
+        "children": [
+          {
+            "type": "textnode",
+            "value": "Option (dynamic):\n"
+          },
+          {
+            "type": "component",
+            "name": "option-text",
+            "properties": {
+              "options": {
+                "type": "expression",
+                "value": "values"
+              },
+              "span": {
+                "type": "value",
+                "value": "5"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/compiler/test/parse/markdown-parse-test.js
+++ b/packages/compiler/test/parse/markdown-parse-test.js
@@ -51,6 +51,10 @@ describe('parseMarkdown', () => {
     await parseTest('article/components.md', 'ast/components.ast.json');
   });
 
+  it('parses properties', async () => {
+    await parseTest('article/properties.md', 'ast/properties.ast.json');
+  });
+
   it('parses include component', async () => {
     await parseTest('article/include.md', 'ast/include.ast.json');
   });

--- a/packages/components/src/range-text.js
+++ b/packages/components/src/range-text.js
@@ -16,16 +16,15 @@ export class RangeText extends DraggableText {
 
   constructor() {
     super();
-    this.value = 0;
     this.step = 1;
     this.min = -1000;
     this.max = +1000;
+    this.value = NaN;
   }
 
   currentIndex() {
     const { min, step, value } = this;
-    const v = +value || 0;
-    return Math.floor((v - min) / step);
+    return isNaN(value) ? 0 : Math.floor((+value - min) / step);
   }
 
   updatedIndex(x1, x2, index) {
@@ -45,10 +44,11 @@ export class RangeText extends DraggableText {
 
   content() {
     if (typeof this.value !== 'number') {
-      return this. value;
+      return this.value;
     } else {
       const digits = Math.max(0, Math.ceil(-Math.log10(this.step)));
-      return this.value.toFixed(digits);
+      const value = Number.isNaN(this.value) ? this.min : this.value;
+      return value.toFixed(digits);
     }
   }
 }

--- a/packages/runtime/src/hydrate.js
+++ b/packages/runtime/src/hydrate.js
@@ -38,7 +38,7 @@ function observeAttrs(resolve, attrs) {
     const node = resolve(target);
     const observer = new Observer((status, value) => {
       if (status === FULFILLED) {
-        node.setAttribute(name, value);
+        node.setAttribute(name, attrValue(value));
       } else if (status === REJECTED) {
         console.error(value.error);
       }
@@ -47,6 +47,10 @@ function observeAttrs(resolve, attrs) {
     node.observers.set(name, observer);
     return observer;
   };
+}
+
+function attrValue(value) {
+  return typeof value === 'object' ? JSON.stringify(value) : value;
 }
 
 function observeEvent(resolve, event, runtime) {


### PR DESCRIPTION
- Call `JSON.stringify` on object values before setting HTML attributes.
- Update `range-text` component for better default value handling.
- Add tests for component properties.