### PR TITLE
feat: add alt text to generated latex images

### DIFF
--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -250,10 +250,9 @@ export class TexFormat {
 
   image(ast) {
     const src = sanitizeFile(getPropertyValue(ast, 'src'));
-    // TODO: find best way to incorporate alt text
-    // const alt = getPropertyValue(ast, 'alt');
+    const alt = getPropertyValue(ast, 'alt');
     const arg = getImageParams(ast);
-    return `\\includegraphics[${arg}]{${src}}`;
+    return `\\includegraphics[${arg}${alt ? `,alt={${alt}}` : ''}]{${src}}`;
   }
 
   quoted(ast) {


### PR DESCRIPTION
See https://github.com/latex3/latex2e/issues/651.

If you add `\DocumentMetadata{testphase=phase-III}` to the beginning of the document, this might just work. See https://www.latex-project.org/publications/2023-UFi-FMi-TUG-tb137fischer-tagging23.pdf for details about the state of tagged documents. 