### PR TITLE
fix: stop double-processing tex in spans

### DIFF
--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -233,7 +233,7 @@ export class TexFormat {
     return this.size(ast, getClasses(ast)
       .map(cls => this.options.classes.get(cls))
       .filter(x => x)
-      .reduce((s, c) => this.command(s, c), this.fragment(ast)));
+      .reduce((s, c) => this.command(s, c), ast));
   }
 
   link(ast) {


### PR DESCRIPTION
Previously, something like `[*emph in span*]{.smallcaps}` would result in "\emph{emph in span}" in small caps (with the LaTeX code visible in the PDF).

Cause: `this.fragment` returns a string, but `this.command` expects an AST as its first argument (cuz it calls `this.fragment` on it itself). So we're transforming to LaTeX and then transforming that to LaTeX again, which treats it as a string of content.