### PR TITLE
feat: latex classToCommand option

### DIFF
--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -42,7 +42,8 @@ export async function outputLatex(ast, context, options) {
     pdf = true,
     stdout = false,
     latexDir = path.join(pdf ? tempDir : outputDir, 'latex'),
-    vspace = {}
+    vspace = {},
+    classToCommand,
   } = options;
 
   const articleName = path.parse(inputFile).name;
@@ -71,7 +72,8 @@ export async function outputLatex(ast, context, options) {
       ['bold', 'textbf'],
       ['strong', 'textbf'],
       ['demi', 'textbf'],
-      ['underline', 'uline']
+      ['underline', 'uline'],
+      ...classToCommand || [],
     ]),
     sizes: new Map([
       ['tiny', 'tiny'],


### PR DESCRIPTION
This adds an option you can put in your YAML to map classes to LaTeX commands.

Motivational story: I wanted to put highlighted text in my paper. I could do this by putting `\myhl{some text}` directly into the md (and defining `\myhl` in a `~~~ latex:preamble`). But 1. this will disappear from HTML output, and 2. the contents of the command won't get parsed. So the idea here is to instead write `[some text]{.myhl}`, set `classToCommand: [['myhl', 'myhl']]` in the yaml frontmatter, define `\myhl` in a `~~~ latex:preamble`, and define a CSS rule for `.myhl` in a linked CSS. It works pretty nicely.