### PR TITLE
feat: use \autoref in latex

### DIFF
--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -58,12 +58,6 @@ export async function outputLatex(ast, context, options) {
   // prepare LaTeX formatter
   const tex = new TexFormat({
     references: citations?.data,
-    prefix: new Map([
-      ['fig', 'Figure~'],
-      ['tbl', 'Table~'],
-      ['eqn', 'Equation~'],
-      ['sec', '\\S']
-    ]),
     // TODO handle colors?
     classes: new Map([
       ['smallcaps', 'textsc'],

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -294,8 +294,8 @@ export class TexFormat {
     const type = getPropertyValue(ast, 'type');
     const xref = getPropertyValue(ast, 'xref');
     const short = getPropertyValue(ast, 'short');
-    const prefix = (!short && this.options.prefix.get(type)) || '';
-    return `${prefix}\\ref{${type}:${xref}}`;
+    const ref = short ? '\\ref' : '\\autoref';
+    return `${ref}{${type}:${xref}}`;
   }
 
   math(ast) {


### PR DESCRIPTION
\autoref automatically adds the prefix and also makes the whole reference ("Figure 3" instead of just "3") clickable.