### PR TITLE
feat: latex classToEnv option

### DIFF
--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -44,6 +44,7 @@ export async function outputLatex(ast, context, options) {
     latexDir = path.join(pdf ? tempDir : outputDir, 'latex'),
     vspace = {},
     classToCommand,
+    nameToEnv,
   } = options;
 
   const articleName = path.parse(inputFile).name;
@@ -86,7 +87,8 @@ export async function outputLatex(ast, context, options) {
       ['huge', 'huge']
     ]),
     places: places(article),
-    vspace: new Map(Object.entries(vspace))
+    vspace: new Map(Object.entries(vspace)),
+    nameToEnv: new Map(nameToEnv || [])
   });
 
   // Marshal template data

--- a/packages/compiler/src/output/latex/index.js
+++ b/packages/compiler/src/output/latex/index.js
@@ -44,7 +44,7 @@ export async function outputLatex(ast, context, options) {
     latexDir = path.join(pdf ? tempDir : outputDir, 'latex'),
     vspace = {},
     classToCommand,
-    nameToEnv,
+    classToEnv,
   } = options;
 
   const articleName = path.parse(inputFile).name;
@@ -88,7 +88,7 @@ export async function outputLatex(ast, context, options) {
     ]),
     places: places(article),
     vspace: new Map(Object.entries(vspace)),
-    nameToEnv: new Map(nameToEnv || [])
+    classToEnv: new Map(classToEnv || [])
   });
 
   // Marshal template data

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -87,6 +87,11 @@ export class TexFormat {
       return; // skip on non-latex output namespace
     }
 
+    const maybeEnv = this.options.nameToEnv.get(ast.name);
+    if (maybeEnv) {
+      return this.env(maybeEnv, this.fragment(ast));
+    }
+
     switch (ast.name) {
       case 'article':
         return this.fragment(ast);

--- a/packages/compiler/src/output/latex/tex-format.js
+++ b/packages/compiler/src/output/latex/tex-format.js
@@ -87,11 +87,6 @@ export class TexFormat {
       return; // skip on non-latex output namespace
     }
 
-    const maybeEnv = this.options.nameToEnv.get(ast.name);
-    if (maybeEnv) {
-      return this.env(maybeEnv, this.fragment(ast));
-    }
-
     switch (ast.name) {
       case 'article':
         return this.fragment(ast);
@@ -102,8 +97,9 @@ export class TexFormat {
       case 'h3':
         return this.header(ast, 2);
       case 'p':
-      case 'div':
         return this.paragraph(ast);
+      case 'div':
+        return this.div(ast);
       case 'hr':
         return this.env('center', '\\rule{0.5\\linewidth}{0.5pt}');
       case 'blockquote':
@@ -232,6 +228,15 @@ export class TexFormat {
       .map(cls => this.options.sizes.get(cls))
       .filter(x => x)
       .reduce((s, c) => `{\\${c} ${s}}`, content);
+  }
+
+  div(ast) {
+    const maybeEnv = getClasses(ast)
+      .map(cls => this.options.classToEnv.get(cls)).find(Boolean);
+    if (maybeEnv) {
+      return this.env(maybeEnv, this.fragment(ast));
+    }
+    return this.paragraph(ast);
   }
 
   span(ast) {


### PR DESCRIPTION
A YAML front-matter option comparable to classToCommand (#103), but this time for turning

```
::: .my-env
...
:::
```

into

```
\begin{my-env}
...
\end{my-env}
```

rather than for turning `[...]{.command}` into `\command{...}`.